### PR TITLE
Change space-after-keywords rule -> keyword-spacing

### DIFF
--- a/index.js
+++ b/index.js
@@ -47,7 +47,7 @@ module.exports = {
     "object-curly-spacing": [ 2, "always" ], // may be high-impact - consider changing
     "quotes": [ 2, "single", "avoid-escape" ],
     "semi": [ 2, "always" ],
-    "space-after-keywords": 2,
+    "keyword-spacing": 2,
     "space-before-blocks": 2,
     "space-before-function-paren": [ 2, { "anonymous": "always", "named": "never" } ],
     "no-bitwise": 2,

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "url": "https://github.com/360incentives/eslint-config-base/issues"
   },
   "homepage": "https://github.com/360incentives/eslint-config-base#readme",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Base eslint configuration.",
   "main": "index.js",
   "scripts": {
@@ -22,6 +22,6 @@
   ],
   "license": "MIT",
   "devDependencies": {
-    "eslint": "^0.24.0"
+    "eslint": "^2.1.0"
   }
 }


### PR DESCRIPTION
  -- fixes lint errors like this one: "Rule 'space-after-keywords' was removed
     and replaced by: keyword-spacing"

Also increment package.json version and change eslint dependency to latest 2.1.0